### PR TITLE
Add PiercingBullet functionality and fix recycled bullet issue

### DIFF
--- a/src/Enemy/CollisionManager.java
+++ b/src/Enemy/CollisionManager.java
@@ -1,0 +1,4 @@
+package Enemy;
+
+public class CollisionManager {
+}

--- a/src/Enemy/PiercingBullet.java
+++ b/src/Enemy/PiercingBullet.java
@@ -1,0 +1,68 @@
+package Enemy;
+
+import java.awt.Color;
+
+import engine.DrawManager;
+import entity.Bullet;
+import entity.Entity;
+
+/**
+ * The PiercingBullet class extends the Bullet class to implement a bullet
+ * that can pierce through multiple enemies based solely on piercing count.
+ */
+public class PiercingBullet extends Bullet {
+
+    // Variable to track how many enemies the bullet can pierce.
+    private int piercingCount;
+
+    /**
+     * Constructor for PiercingBullet.
+     *
+     * @param positionX Initial X position of the bullet.
+     * @param positionY Initial Y position of the bullet.
+     * @param speed Speed of the bullet, positive is down, negative is up.
+     * @param piercingCount Number of enemies the bullet can pierce.
+     */
+    public PiercingBullet(final int positionX, final int positionY, final int speed, int piercingCount) {
+        super(positionX, positionY, speed);  // Piercing bullets do not use isPiercing flag anymore.
+        this.piercingCount = piercingCount;
+    }
+
+    /**
+     * Handles the logic when the bullet collides with an entity.
+     * Reduces the piercing count and destroys the bullet when piercing is exhausted.
+     *
+     * @param entity The entity the bullet collided with.
+     */
+    public void onCollision(Entity entity) {
+        this.piercingCount--;
+        if (this.piercingCount <= 0) {
+            this.destroy(); // Destroys the bullet when it can no longer pierce.
+        }
+    }
+
+    /**
+     * Getter for the number of remaining piercings.
+     *
+     * @return The remaining piercings.
+     */
+    public int getPiercingCount() {
+        return piercingCount;
+    }
+
+    /**
+     * Setter for the piercing count.
+     *
+     * @param piercingCount The new number of piercings the bullet can perform.
+     */
+    public void setPiercingCount(int piercingCount) {
+        this.piercingCount = piercingCount;
+    }
+
+    /**
+     * Destroys the ship, causing an explosion.
+     */
+    public void destroy() {
+        this.spriteType = DrawManager.SpriteType.Explosion;
+    }
+}

--- a/src/Enemy/PiercingBulletPool.java
+++ b/src/Enemy/PiercingBulletPool.java
@@ -1,0 +1,61 @@
+package Enemy;
+
+import entity.Bullet;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Implements a pool of recyclable bullets.
+ *
+ * @author <a href="mailto:RobertoIA1987@gmail.com">Roberto Izquierdo Amo</a>
+ *
+ */
+public final class PiercingBulletPool {
+
+    /** Set of already created PiercingBullets available for reuse. */
+    private static Set<PiercingBullet> pool = new HashSet<>();
+
+    /**
+     * Constructor, not called.
+     */
+    private PiercingBulletPool() {
+
+    }
+
+
+    /**
+     * Retrieves a piercing bullet from the pool if one is available, or creates a new one if the pool is empty.
+     *
+     * @param positionX The requested X position for the bullet.
+     * @param positionY The requested Y position for the bullet.
+     * @param speed The speed of the bullet, positive or negative depending on direction.
+     * @param piercingCount The number of enemies the bullet can pierce.
+     * @return A PiercingBullet object, either from the pool or newly created.
+     */
+    public static PiercingBullet getPiercingBullet(final int positionX,
+                                                   final int positionY, final int speed, int piercingCount) {
+        PiercingBullet bullet;
+        if (!pool.isEmpty()) {
+            bullet = pool.iterator().next();
+            pool.remove(bullet); // Remove the bullet from the pool for use
+            bullet.setPositionX(positionX - bullet.getWidth() / 2);
+            bullet.setPositionY(positionY);
+            bullet.setSpeed(speed);
+            bullet.setPiercingCount(piercingCount);  // Reset piercing count when recycling
+        } else {
+            bullet = new PiercingBullet(positionX, positionY, speed, piercingCount);
+            bullet.setPositionX(positionX - bullet.getWidth() / 2);
+        }
+        return bullet;
+    }
+    /**
+     * Adds one or more bullets to the list of available ones.
+     *
+     * @param bullets
+     *            Bullets to recycle.
+     */
+    public static void recycle(final Set<PiercingBullet> bullets) {
+        pool.addAll(bullets);
+    }
+}

--- a/src/Enemy/PiercingBulletPool.java
+++ b/src/Enemy/PiercingBulletPool.java
@@ -43,6 +43,7 @@ public final class PiercingBulletPool {
             bullet.setPositionY(positionY);
             bullet.setSpeed(speed);
             bullet.setPiercingCount(piercingCount);  // Reset piercing count when recycling
+            bullet.setSprite(); // Prevents destroyed bullets from being reused incorrectly
         } else {
             bullet = new PiercingBullet(positionX, positionY, speed, piercingCount);
             bullet.setPositionX(positionX - bullet.getWidth() / 2);

--- a/src/entity/EnemyShipFormation.java
+++ b/src/entity/EnemyShipFormation.java
@@ -7,13 +7,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import Enemy.PiercingBullet;
 import screen.Screen;
 import engine.Cooldown;
 import engine.Core;
 import engine.DrawManager;
 import engine.DrawManager.SpriteType;
 import engine.GameSettings;
-
+import Enemy.PiercingBulletPool;
 /**
  * Groups enemy ships into a formation that moves together.
  * 
@@ -330,15 +331,18 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 	 * @param bullets
 	 *            Bullets set to add the bullet being shot.
 	 */
-	public final void shoot(final Set<Bullet> bullets) {
+	public final void shoot(final Set<PiercingBullet> bullets) {
 		// For now, only ships in the bottom row are able to shoot.
 		int index = (int) (Math.random() * this.shooters.size());
 		EnemyShip shooter = this.shooters.get(index);
 
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
-			bullets.add(BulletPool.getBullet(shooter.getPositionX()
-					+ shooter.width / 2, shooter.getPositionY(), BULLET_SPEED));
+			bullets.add(PiercingBulletPool.getPiercingBullet(
+					shooter.getPositionX() + shooter.width / 2,
+					shooter.getPositionY(),
+					BULLET_SPEED,
+					0));
 		}
 	}
 

--- a/src/entity/Ship.java
+++ b/src/entity/Ship.java
@@ -3,9 +3,11 @@ package entity;
 import java.awt.Color;
 import java.util.Set;
 
+import Enemy.PiercingBullet;
 import engine.Cooldown;
 import engine.Core;
 import engine.DrawManager.SpriteType;
+import Enemy.PiercingBulletPool;
 
 /**
  * Implements a ship, to be controlled by the player.
@@ -66,11 +68,18 @@ public class Ship extends Entity {
 	 *            List of bullets on screen, to add the new bullet.
 	 * @return Checks if the bullet was shot correctly.
 	 */
-	public final boolean shoot(final Set<Bullet> bullets) {
+	public final boolean shoot(final Set<PiercingBullet> bullets) {
 		if (this.shootingCooldown.checkFinished()) {
 			this.shootingCooldown.reset();
-			bullets.add(BulletPool.getBullet(positionX + this.width / 2,
-					positionY, BULLET_SPEED));
+
+			// Add a piercing bullet fired by the player's ship.
+			// This bullet can pierce 2 enemy ships.
+			bullets.add(PiercingBulletPool.getPiercingBullet(
+					positionX + this.width / 2,
+					positionY,
+					BULLET_SPEED,
+					2 // Number of enemies the bullet can pierce
+			));
 			return true;
 		}
 		return false;


### PR DESCRIPTION
- Added PiercingBullet functionality, allowing bullets to reduce their piercing count upon collision, and get recycled when they can no longer pierce.
- Modified the existing bullet collision logic to ensure that PiercingBullets properly pierce through enemies.
- Fixed a significant issue where recycled bullets were being fired in an exploded state. This fix prevents previously destroyed bullets from being unintentionally reused in an invalid state, which caused unexpected behavior.