### PR TITLE
FEAT: Add a temporary boss on Level 3

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -49,7 +49,7 @@ public final class Core {
 			new GameSettings(5, 5, 50, 2500, 1);
 	/** Difficulty settings for level 3. */
 	private static final GameSettings SETTINGS_LEVEL_3 =
-			new GameSettings(6, 5, 40, 1500, 1);
+			new GameSettings(1, 1, -8, 200, 1);
 	/** Difficulty settings for level 4. */
 	private static final GameSettings SETTINGS_LEVEL_4 =
 			new GameSettings(6, 6, 30, 1500, 2);

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -734,7 +734,11 @@ public class DrawManager {
 				rectWidth, rectHeight);
 		backBufferGraphics.setColor(Color.GREEN);
 		if (number >= 4)
-			if (!bonusLife) {
+			// Adjust the numbers here to match the appropriate boss levels.
+			if (level == 3) { // Edited by team Enemy // ex) (level == 3 || level == 6 || level == 9)
+				drawCenteredBigString(screen, "BOSS",
+						screen.getHeight() / 2 + fontBigMetrics.getHeight() / 3);
+			} else if (!bonusLife) {
 				drawCenteredBigString(screen, "Level " + level,
 						screen.getHeight() / 2
 								+ fontBigMetrics.getHeight() / 3);


### PR DESCRIPTION
I added a temporary boss on Level 3.

Previously, I had mentioned in a pull request to the TA repository that I planned to exclude the boss enemy ship due to the potential for numerous errors. However, in order to stay true to the initial plans outlined in the README.md file and to collaborate with the team working on boss-related development, I have temporarily added a simple placeholder boss to level 3.