### PR TITLE
FIX :Shooters bug fix

### DIFF
--- a/src/entity/EnemyShipFormation.java
+++ b/src/entity/EnemyShipFormation.java
@@ -418,17 +418,19 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 	 */
 	public final void shoot(final Set<PiercingBullet> bullets) { // Edited by Enemy
 		// For now, only ships in the bottom row are able to shoot.
-		int index = (int) (random() * this.shooters.size());
-		EnemyShip shooter = this.shooters.get(index);
-		if (this.shootingCooldown.checkFinished()) {
-			this.shootingCooldown.reset();
-			sm = SoundManager.getInstance();
-			sm.playES("Enemy_Gun_Shot_1_ES");
-			bullets.add(PiercingBulletPool.getPiercingBullet( // Edited by Enemy
-					shooter.getPositionX() + shooter.width / 2,
-					shooter.getPositionY(),
-					BULLET_SPEED,
-					0)); // Edited by Enemy
+		if (!shooters.isEmpty()) { // Added by team Enemy
+			int index = (int) (random() * this.shooters.size());
+			EnemyShip shooter = this.shooters.get(index);
+			if (this.shootingCooldown.checkFinished()) {
+				this.shootingCooldown.reset();
+				sm = SoundManager.getInstance();
+				sm.playES("Enemy_Gun_Shot_1_ES");
+				bullets.add(PiercingBulletPool.getPiercingBullet( // Edited by Enemy
+						shooter.getPositionX() + shooter.width / 2,
+						shooter.getPositionY(),
+						BULLET_SPEED,
+						0)); // Edited by Enemy
+			}
 		}
 	}
 


### PR DESCRIPTION
## What
This PR fix bug that the game freezes when 'shooters' are empty.

## How
Added `if` statement just in case an enemy trys to shoot even though `shooter`'s size is 0.

## Related Issue
https://github.com/dev-jjjjjeong-bin/Invaders-SDP/issues/79#issue-2583790133