### PR TITLE
[Fix] Immortality bug

### DIFF
--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -386,7 +386,7 @@ public class GameScreen extends Screen {
 		*
 		* Checks if the intended number of waves for this level was destroyed
 		* **/
-		if ((getRemainingEnemies() == 0 || this.lives == 0)
+		if ((getRemainingEnemies() == 0 || this.lives <= 0) // Edited by team Enemy
 		&& !this.levelFinished
 		&& waveCounter == this.gameSettings.getWavesNumber()) {
 			this.levelFinished = true;
@@ -603,7 +603,7 @@ public class GameScreen extends Screen {
 								+ " lives remaining.");
 
 						// Sound Operator
-						if (this.lives == 0){
+						if (this.lives <= 0){ // Edited by team Enemy
 							sm = SoundManager.getInstance();
 							sm.playShipDieSounds();
 						}

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -389,6 +389,7 @@ public class GameScreen extends Screen {
 		if ((getRemainingEnemies() == 0 || this.lives <= 0) // Edited by team Enemy
 		&& !this.levelFinished
 		&& waveCounter == this.gameSettings.getWavesNumber()) {
+			this.lives = 0;
 			this.levelFinished = true;
 			this.screenFinishedCooldown.reset();
 		}


### PR DESCRIPTION
## What
Fix immortality bug.
Occurred when player's ship get hit by and obstacle and enemy bullet at the same time when player's hp is 1. If happens, hp became -1 and the game would never end.

## Related Issue
https://github.com/dev-jjjjjeong-bin/Invaders-SDP/issues/95