### PR TITLE
FEAT: Add boss flag & Insert hp5 big boss on L2

### DIFF
--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -45,25 +45,25 @@ public final class Core {
 	
 	/** Difficulty settings for level 1. */
 	private static final GameSettings SETTINGS_LEVEL_1 =
-			new GameSettings(5, 4, 60, 2000, 1);
+			new GameSettings(5, 4, 60, 2000, 1, false);
 	/** Difficulty settings for level 2. */
 	private static final GameSettings SETTINGS_LEVEL_2 =
-			new GameSettings(5, 5, 50, 2500, 1);
+			new GameSettings(1, 1, 50, 2500, 1, true);
 	/** Difficulty settings for level 3. */
 	private static final GameSettings SETTINGS_LEVEL_3 =
-			new GameSettings(1, 1, -8, 500, 1);
+			new GameSettings(1, 1, -8, 500, 1, false);
 	/** Difficulty settings for level 4. */
 	private static final GameSettings SETTINGS_LEVEL_4 =
-			new GameSettings(6, 6, 30, 1500, 2);
+			new GameSettings(6, 6, 30, 1500, 2, false);
 	/** Difficulty settings for level 5. */
 	private static final GameSettings SETTINGS_LEVEL_5 =
-			new GameSettings(7, 6, 20, 1000, 2);
+			new GameSettings(7, 6, 20, 1000, 2, false);
 	/** Difficulty settings for level 6. */
 	private static final GameSettings SETTINGS_LEVEL_6 =
-			new GameSettings(7, 7, 10, 1000, 3);
+			new GameSettings(7, 7, 10, 1000, 3, false);
 	/** Difficulty settings for level 7. */
 	private static final GameSettings SETTINGS_LEVEL_7 =
-			new GameSettings(8, 7, 2, 500, 1);
+			new GameSettings(8, 7, 2, 500, 1, false);
 	
 	/** Frame to draw the screen on. */
 	private static Frame frame;

--- a/src/engine/GameSettings.java
+++ b/src/engine/GameSettings.java
@@ -19,6 +19,8 @@ public class GameSettings {
 	/** Level Design team modification
 	 * Number of enemy ships waves during the level **/
 	private int wavesNumber;
+	/** Flag to indicate boss level */
+	private boolean isBossLevel;
 
 	/**
 	 * Constructor.
@@ -33,9 +35,11 @@ public class GameSettings {
 	 *            Frecuency of enemy shootings, +/- 30%.
 	 * @param wavesNumber
 	 * 				Number of waves in the level (Added by the Level Design team)
+	 * @param isBossLevel
+	 * 				Indicates if this level is a boss level.
 	 */
 	public GameSettings(final int formationWidth, final int formationHeight,
-			final int baseSpeed, final int shootingFrecuency, final int wavesNumber) {
+                        final int baseSpeed, final int shootingFrecuency, final int wavesNumber, final boolean isBossLevel) {
 		this.formationWidth = formationWidth;
 		this.formationHeight = formationHeight;
 		this.baseSpeed = baseSpeed;
@@ -43,6 +47,12 @@ public class GameSettings {
 
 		/** Added by the Level Design team **/
 		this.wavesNumber = wavesNumber;
+
+		this.isBossLevel = isBossLevel;
+    }
+	// Getter for isBossLevel
+	public boolean isBossLevel() {
+		return isBossLevel;
 	}
 
 	/**

--- a/src/entity/EnemyShipFormation.java
+++ b/src/entity/EnemyShipFormation.java
@@ -185,26 +185,32 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 			int y=0;
 			for (int i = 0; i < this.nShipsHigh; i++) {
 				double angle = 2* PI * i / this.nShipsHigh;
+				if (gameSettings.isBossLevel()) {
+					spriteType = SpriteType.Boss;
+					x = positionX;
+					y = positionY;
+					hp = 5;
+				}else {
+					if (i / (float) this.nShipsHigh < PROPORTION_C)
+						if (shipCount == (nShipsHigh * 1) + 1 || shipCount == (nShipsHigh * 3) + 1) //Edited by Enemy
+							spriteType = SpriteType.ExplosiveEnemyShip1;
+						else if (i / (float) this.nShipsHigh < PROPORTION_C)
+							spriteType = SpriteType.EnemyShipC1;
+						else if (i / (float) this.nShipsHigh < PROPORTION_B + PROPORTION_C)
+							spriteType = SpriteType.EnemyShipB1;
+						else
+							spriteType = SpriteType.EnemyShipA1;
+					if (isCircle) {
+						x = (int) round(RADIUS * cos(angle) + positionX + (SEPARATION_DISTANCE_CIRCLE * this.enemyShips.indexOf(column)));
+						y = (int) (RADIUS * sin(angle)) + positionY;
+					} else {
+						x = positionX + (SEPARATION_DISTANCE * this.enemyShips.indexOf(column));
+						y = positionY + i * SEPARATION_DISTANCE;
+					}
 
-				if (i / (float) this.nShipsHigh < PROPORTION_C)
-        if (shipCount == (nShipsHigh*1)+1 ||shipCount == (nShipsHigh*3)+1) //Edited by Enemy
-					spriteType = SpriteType.ExplosiveEnemyShip1;
-				else if (i / (float) this.nShipsHigh < PROPORTION_C)
-					spriteType = SpriteType.EnemyShipC1;
-				else if (i / (float) this.nShipsHigh < PROPORTION_B + PROPORTION_C)
-					spriteType = SpriteType.EnemyShipB1;
-				else
-					spriteType = SpriteType.EnemyShipA1;
-				if(isCircle){
-				x = (int) round(RADIUS * cos(angle) + positionX + ( SEPARATION_DISTANCE_CIRCLE* this.enemyShips.indexOf(column)));
-				y = (int) (RADIUS * sin(angle)) + positionY;}
-				else{
-					x = positionX + (SEPARATION_DISTANCE * this.enemyShips.indexOf(column));
-					y = positionY+ i*SEPARATION_DISTANCE;
+					if (shipCount == nShipsHigh * (nShipsWide / 2))
+						hp = 2; // Edited by Enemy, It just an example to insert EnemyShip that hp is 2.
 				}
-
-				if(shipCount == nShipsHigh*(nShipsWide/2))
-					hp = 2; // Edited by Enemy, It just an example to insert EnemyShip that hp is 2.
 
 				column.add(new EnemyShip(x, y, spriteType,hp,this.enemyShips.indexOf(column),i));// Edited by Enemy
 				this.shipCount++;
@@ -228,7 +234,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 
 	/**
 	 * Associates the formation to a given screen.
-	 * 
+	 *
 	 * @param newScreen
 	 *            Screen to attach.
 	 */
@@ -255,7 +261,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 					shootingVariance);
 			this.shootingCooldown.reset();
 		}
-		
+
 		cleanUp();
 
 		int movementX = 0;
@@ -265,7 +271,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 		this.movementSpeed = (int) (pow(remainingProportion, 2)
 				* this.baseSpeed);
 		this.movementSpeed += MINIMUM_SPEED;
-		
+
 		movementInterval++;
 		if (movementInterval >= this.movementSpeed) {
 			movementInterval = 0;
@@ -394,7 +400,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 
 		int leftMostPoint = 0;
 		int rightMostPoint = 0;
-		
+
 		for (List<EnemyShip> column : this.enemyShips) {
 			if (!column.isEmpty()) {
 				if (leftMostPoint == 0)
@@ -412,7 +418,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 
 	/**
 	 * Shoots a bullet downwards.
-	 * 
+	 *
 	 * @param bullets
 	 *            Bullets set to add the bullet being shot.
 	 */
@@ -480,7 +486,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 	}
 	/**
 	 * Gets the ship on a given column that will be in charge of shooting.
-	 * 
+	 *
 	 * @param column
 	 *            Column to search.
 	 * @return New shooter ship.
@@ -499,7 +505,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 
 	/**
 	 * Returns an iterator over the ships in the formation.
-	 * 
+	 *
 	 * @return Iterator over the enemy ships.
 	 */
 	@Override
@@ -515,7 +521,7 @@ public class EnemyShipFormation implements Iterable<EnemyShip> {
 
 	/**
 	 * Checks if there are any ships remaining.
-	 * 
+	 *
 	 * @return True when all ships have been destroyed.
 	 */
 	public final boolean isEmpty() {

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -226,7 +226,7 @@ public class GameScreen extends Screen {
 		drawManager.loadBackground(this.level);
 
 		// Use BossEnemyShipFormation on specific levels (2, 4, 6)
-		if (this.level == 2 || this.level == 4 || this.level == 6) {
+		if (this.gameSettings.isBossLevel()) {
 			enemyShipFormation = new EnemyShipFormation(this.gameSettings); ////////////////////////////////////Change this to BossEnemyShipFormation - Gyeongju
 		} else {
 			enemyShipFormation = new EnemyShipFormation(this.gameSettings);

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -17,6 +17,7 @@ import entity.Bullet;
 import entity.BulletPool;
 import entity.EnemyShip;
 import entity.EnemyShipFormation;
+// import entity.BossEnemyShipFormation; ////////////////////////////////////////////////////////////////////////////////////// Activate or change this line - Gyeongju
 import entity.Entity;
 import entity.Obstacle;
 import entity.Ship;
@@ -62,6 +63,8 @@ public class GameScreen extends Screen {
 	private int level;
 	/** Formation of enemy ships. */
 	private EnemyShipFormation enemyShipFormation;
+	/** Formation of boss enemy ships. */
+	// private BossEnemyShipFormation bossEnemyShipFormation; //////////////////////////////////////////////////////////////////////Activate or change this line - Gyeongju
 	/** Player's ship. */
 	private Ship ship;
 	/** Bonus enemy ship that appears sometimes. */
@@ -222,7 +225,13 @@ public class GameScreen extends Screen {
 		/** initialize background **/
 		drawManager.loadBackground(this.level);
 
-		enemyShipFormation = new EnemyShipFormation(this.gameSettings);
+		// Use BossEnemyShipFormation on specific levels (2, 4, 6)
+		if (this.level == 2 || this.level == 4 || this.level == 6) {
+			enemyShipFormation = new EnemyShipFormation(this.gameSettings); ////////////////////////////////////Change this to BossEnemyShipFormation - Gyeongju
+		} else {
+			enemyShipFormation = new EnemyShipFormation(this.gameSettings);
+		}
+
 		enemyShipFormation.setScoreManager(this.scoreManager);//add by team Enemy
 		enemyShipFormation.attach(this);
 		this.ship = new Ship(this.width / 2, this.height - 30);


### PR DESCRIPTION
I've created a boss flag that can be modified through the game settings parameter in Core. Jimin, please refer to the Obstacle logic in Entity for adjusting hit detection within the checkCollision function.

Additionally, in GameScreen, if we decide to introduce a separate BossEnemyShip class for the boss enemy, we’ll need to call a different EnemyShipFormation, for boss. I've implemented the required logic to handle this. If you decide to include the boss enemy, please revise the '///////////' marked sections appropriately and remove the markers once done. Please review and confirm.

<img width="758" alt="스크린샷 2024-11-05 오후 6 25 55" src="https://github.com/user-attachments/assets/c5420a7b-cdeb-4933-972b-10f99a97c668">

Jimin, please add your comments as this follows your previous work. For the other two team members developing the boss class, the first to review should complete their review and proceed with the merge. Thank you!
