### PR TITLE
FEAT: Improve boss health-based color transitions

### DIFF
--- a/src/entity/BossParts.java
+++ b/src/entity/BossParts.java
@@ -14,6 +14,7 @@ import java.awt.*;
 public class BossParts extends Entity {
 	/** Part of the Boss' health point */
 	private int hp;
+	private int maxHp;
 
 	/** Cooldown between sprite changes. */
 	private Cooldown animationCooldown;
@@ -43,9 +44,10 @@ public class BossParts extends Entity {
 	public BossParts(final int positionX, final int positionY,
 					 final SpriteType spriteType, int hp) {
 
-		super(positionX, positionY, 12 * 2, 24 * 2, determineColor(hp));
+		super(positionX, positionY, 12 * 2, 24 * 2, determineColor(hp, hp));
 
 		this.hp = hp;
+		this.maxHp = hp;
 		this.spriteType = spriteType;
 		this.animationCooldown = Core.getCooldown(500);
 		this.isDestroyed = false;
@@ -121,13 +123,33 @@ public class BossParts extends Entity {
 	 * 			The Boss' hp
 	 * @return color of Boss
 	 */
-	public static Color determineColor(int hp) {
-		if(hp <= 1) return Color.red;
-		else if(hp <= 5) return Color.green;
-		else if (hp <= 8) return Color.blue;
-		else return Color.white;
-	}
+	public static Color determineColor(int hp, int maxHp) {
 
+		if (hp <= 0) return Color.WHITE;
+
+		hp--;
+		maxHp--;
+
+		int red = 0, green = 0, blue = 0;
+		double ratio = (double) hp * 4 / maxHp;
+
+		if (hp >= (double) maxHp / 2) {
+			blue = (int) (127 * (ratio - 2));
+			green = 255 - (int) (127 * ((ratio - 2)));
+		}else if (hp >= (double) maxHp / 4) {
+			green = 255;
+			red = 255 -(int) (255 * (ratio -1));
+		}else {
+			green = (int) (255 * ratio);
+			red = 255;
+		}
+
+		red = Math.min(255, Math.max(0, red));
+		green = Math.min(255, Math.max(0, green));
+		blue = Math.min(255, Math.max(0, blue));
+
+		return new Color(red, green, blue);
+	}
 	public final void changeColor() {
 	}
 
@@ -145,7 +167,7 @@ public class BossParts extends Entity {
 			sm.playES("hit_enemy");
 		}
 
-		bossParts.setColor(determineColor(hp));
+		bossParts.setColor(determineColor(hp, bossParts.maxHp));
 	}
 
 	/**


### PR DESCRIPTION
## Change Summary
- Refactored the boss health-based color transition logic to implement smooth gradient effects.
- Divided health into segments for gradual color changes:
  > **100% - 75%**: Blue (`#0000FF`) → Cyan (`#008080`)
  > **75% - 50%**: Cyan (`#008080`) → Green (`#00FF00`)
  >  **50% - 25%**: Green (`#00FF00`) → Yellow (`#FFFF00`)
  >  **25% - HP1**: Yellow (`#FFFF00`) → Red (`#FF0000`)
  >  See the gradient diagram below for more details on color transitions.
- Ensured RGB values remain within the valid range (0–255) for safety.

## Reason for Change
- The previous logic used simplistic color transitions, lacking intuitive feedback tied to the boss's health state.
- The new smooth gradient effect allows players to visually assess the boss's health more easily and intuitively.

_____________________________________________________________________________________________________________________________

## 변경 사항
- 기존의 단순 색상 전환 로직을 보스 체력에 따른 부드러운 그라데이션 효과로 개선.
- 체력을 구간별로 나눠 색깔 변경
  >100% - 75% 파란색(`#0000FF`) - 청록색(`#008080`)
  >75% - 50% 청록색(`#008080`) - 초록색(`#00FF00`)
  > 50%~25% 초록색(`#00FF00`) - 노란색(`#FFFF00`)
  > 25%~HP1 노란색 (`#FFFF00`) - 빨간색(`#FF0000`)
  > 자세한 색상 변동 사항은 하단 그라데이션 사진 참조
- RGB 값의 안전성을 보장하기 위해 0~255 범위를 초과하지 않도록 제한 추가.

## 변경 이유
- 기존 로직은 체력 구간별로 색상이 단순하게 변화했으며, 체력에 따른 직관적 피드백이 부족했습니다.
- 부드러운 그라데이션 효과를 통해 플레이어가 보스의 체력 상태를 시각적으로 더 쉽게 파악할 수 있도록 개선했습니다.

![그림1](https://github.com/user-attachments/assets/a91d911e-5bda-434b-b267-5385ad688bfa)

