### PR TITLE
FEAT: Boss Sprite Changes to Damaged Sprite when Boss hit

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -20,7 +20,6 @@ import entity.Coin;
 import inventory_develop.Bomb;
 import screen.Screen;
 import entity.Entity;
-import engine.GameSettings;
 
 import level_design.Background;
 
@@ -129,7 +128,7 @@ public class DrawManager {
 
 		BossBCore1,
 		BossBCore2,
-		BossBCore3
+		BossBCoreDamaged
 
 	};
 
@@ -187,7 +186,7 @@ public class DrawManager {
 			// Turtle
 			spriteMap.put(SpriteType.BossBCore1, new boolean[30][36]);
 			spriteMap.put(SpriteType.BossBCore2, new boolean[30][36]);
-			spriteMap.put(SpriteType.BossBCore3, new boolean[30][36]);
+			spriteMap.put(SpriteType.BossBCoreDamaged, new boolean[30][36]);
 
 			fileManager.loadSprite(spriteMap);
 			logger.info("Finished loading the sprites.");

--- a/src/entity/BossParts.java
+++ b/src/entity/BossParts.java
@@ -1,12 +1,14 @@
 package entity;
 
-import Enemy.HpEnemyShip;
 import Sound_Operator.SoundManager;
 import engine.Cooldown;
 import engine.Core;
 import engine.DrawManager.SpriteType;
 
 import java.awt.*;
+
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * Implements the part of the Boss.
@@ -112,7 +114,7 @@ public class BossParts extends Entity {
 				case BossBCore1:
 					// Check skill cooldown and change sprite type to B3 which is B3.
 					if (this.bossBActiveSkillCooldown.checkFinished()) {
-						this.spriteType = SpriteType.BossBCore3;
+						this.spriteType = SpriteType.BossBCoreDamaged;
 						bossBDeActiveSkillCooldown.reset();
 					}
 					else
@@ -121,13 +123,13 @@ public class BossParts extends Entity {
 				case BossBCore2:
 					this.spriteType = SpriteType.BossBCore1;
 					break;
-				case BossBCore3:
+				case BossBCoreDamaged:
 					if (this.bossBDeActiveSkillCooldown.checkFinished()) {
 						this.spriteType = SpriteType.BossBCore1;
 						bossBActiveSkillCooldown.reset();
 					}
 					else
-						this.spriteType = SpriteType.BossBCore3;
+						this.spriteType = SpriteType.BossBCoreDamaged;
 				default:
 					break;
 			}
@@ -175,13 +177,28 @@ public class BossParts extends Entity {
 		hp -= 1;
 		bossParts.setHp(hp);
 
-		// Maybe we should add blinking effect here when the Boss get hit.
-
 		if (hp <= 0) {
 			bossParts.destroy();
 		}else{
 			sm = SoundManager.getInstance();
 			sm.playES("hit_enemy");
+
+			SpriteType originalSprite = bossParts.getSpriteType();
+			String originalSpriteName = originalSprite.name();
+			String damagedSpriteName = originalSpriteName.replaceAll("\\d+$", "") + "Damaged"; // Search for sprite names that have 'Damaged'
+			try {
+				SpriteType damagedSpriteType = SpriteType.valueOf(damagedSpriteName);
+				bossParts.setSpriteType(damagedSpriteType);
+
+				new Timer().schedule(new TimerTask() {
+					@Override
+					public void run() {
+						bossParts.setSpriteType(originalSprite);
+					}
+				}, 100);
+			} catch (IllegalArgumentException e) {
+				System.err.println("Damaged sprite type not found: " + damagedSpriteName);
+			}
 		}
 
 		bossParts.setColor(determineColor(hp, bossParts.maxHp));

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -6,11 +6,9 @@ import java.util.*;
 
 import java.io.IOException;
 
-import CtrlS.RoundState;
 import clove.AchievementConditions;
 import clove.Statistics;
 import Enemy.*;
-import HUDTeam.DrawAchievementHud;
 import HUDTeam.DrawManagerImpl;
 import engine.*;
 import entity.*;
@@ -20,9 +18,6 @@ import inventory_develop.*;
 import Sound_Operator.SoundManager;
 import clove.ScoreManager;    // CLOVE
 import twoplayermode.TwoPlayerMode;
-import engine.DrawManager.SpriteType;
-
-import javax.imageio.ImageIO;
 
 
 /**
@@ -712,7 +707,7 @@ public class GameScreen extends Screen {
 					for (BossParts bossParts : this.bossFormation) {
 						if (!bossParts.isDestroyed()
 								&& checkCollision(bullet, bossParts)) {
-							if (bossParts.getSpriteType().equals(DrawManager.SpriteType.BossBCore3)) {
+							if (bossParts.getSpriteType().equals(DrawManager.SpriteType.BossBCoreDamaged)) {
 								isShell = true;
 							}
 							else {


### PR DESCRIPTION
## What
This feature works by determining if there is a Damaged sprite for the current sprite when a hit occurs.
If a Damaged sprite exists, it changes to the Damaged sprite for 0.1 seconds before reverting to the original.

## Additional Information
Changed BossB3 Sprite name to BossBDamaged.
Crab Boss does not have Damaged Sprite.
So this feature only works with Turtle Boss.