### PR TITLE
FIX: Improve reviewer logic and add PR title conditions #1

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,4 +1,4 @@
-name: Assign Random Reviewers
+name: 무작위 리뷰어 할당
 
 on:
   pull_request:
@@ -17,6 +17,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # PR 제목 가져오기
+          PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
+          echo "PR 제목: $PR_TITLE"
+          
           # 7명의 조원 GitHub 아이디를 배열에 저장
           REVIEWERS=("Dream-no24" "depave" "this-yujunkim" "gmvolt" "Jangjimin9766" "HSHyun" "NaJhinY")
           
@@ -30,9 +34,19 @@ jobs:
               FILTERED_REVIEWERS+=("$reviewer")
             fi
           done
-          
-          # 배열에서 2명을 무작위로 선택
-          SELECTED_REVIEWERS=($(shuf -e "${FILTERED_REVIEWERS[@]}" -n 2))
+          # PR 제목에서 '#M' 패턴 찾기
+          if [[ "$PR_TITLE" =~ #M$ ]]; then
+            exit 0  # 워크플로우 종료 (자동 리뷰어 할당을 하지 않음)
+          # PR 제목에서 '#n' 패턴 찾기
+          elif [[ "$PR_TITLE" =~ #([0-9]+)$ ]]; then
+            NUM_REVIEWERS=${BASH_REMATCH[1]}
+            echo "지정된 리뷰어 수: $NUM_REVIEWERS"
+          else
+            NUM_REVIEWERS=2
+            echo "리뷰어 수가 명시되지 않았으므로 기본값 $NUM_REVIEWERS명을 선택합니다."
+          fi
+          # 배열에서 n명을 무작위로 선택
+          SELECTED_REVIEWERS=($(shuf -e "${FILTERED_REVIEWERS[@]}" -n "$NUM_REVIEWERS"))
           
           echo "선택된 리뷰어: ${SELECTED_REVIEWERS[@]}"
           

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -35,10 +35,11 @@ jobs:
             fi
           done
           # PR 제목에서 '#M' 패턴 찾기
-          if [[ "$PR_TITLE" =~ #M$ ]]; then
+          if [[ "$PR_TITLE" =~ \#M$ ]]; then
             exit 0  # 워크플로우 종료 (자동 리뷰어 할당을 하지 않음)
+          fi
           # PR 제목에서 '#n' 패턴 찾기
-          elif [[ "$PR_TITLE" =~ #([0-9]+)$ ]]; then
+          if [[ "$PR_TITLE" =~ \#([0-9]+)$ ]]; then
             NUM_REVIEWERS=${BASH_REMATCH[1]}
             echo "지정된 리뷰어 수: $NUM_REVIEWERS"
           else

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: Auto Merge PR on Approval  # 워크플로우 이름 설정
+name: 승인 조건 충족 시 PR 자동 병합
 
 on:
   pull_request_review:
@@ -16,14 +16,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq gh  # JSON 파싱과 GitHub CLI 사용을 위한 jq와 gh 설치
 
-      - name: Check out the code
-        uses: actions/checkout@v4  # PR 코드 체크아웃
+      - name: 코드 체크아웃
+        uses: actions/checkout@v4
 
       - name: Install jq
         # jq 설치 (JSON 파싱 도구)
         run: sudo apt-get install -y jq
 
-      - name: Check PR Approval Status
+      - name: PR 승인 상태 확인
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # GitHub API 접근을 위한 토큰 설정
         run: |
@@ -43,11 +43,24 @@ jobs:
           echo "PR 번호: $PR_NUMBER"  # PR 번호 출력하여 확인
           
           # PR 번호가 제대로 가져와지지 않았을 경우 에러 메시지 출력 및 종료
+
           if [ -z "$PR_NUMBER" ]; then
             echo "Error: PR 번호를 가져오지 못했습니다."
             exit 1
           fi
-          
+
+          # 모든 리뷰어 정보 가져오기
+          REVIEWERS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" | jq '.reviewers | length')
+
+          echo "리뷰어 수: $REVIEWERS"
+
+          # 리뷰어가 0명일 경우 자동 병합 중단
+          if [ "$REVIEWERS" -eq 0 ]; then
+            echo "리뷰어가 없으므로 자동 병합을 수행하지 않습니다."
+            exit 0
+          fi
+
           # 승인 상태를 확인하기 위해 모든 리뷰 정보 가져오기
           REVIEWS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews")
@@ -59,7 +72,7 @@ jobs:
           echo "승인된 리뷰어 수: $APPROVAL_COUNT"  # 승인된 리뷰어 수 출력
 
           # 필요한 승인 수 정의 (예: 2명)
-          REQUIRED_APPROVALS=2  # 최소 승인자 수 설정
+          REQUIRED_APPROVALS=$REVIEWERS
 
           # 승인 수가 필요한 승인 수 이상일 때 approved=true 설정
           if [ "$APPROVAL_COUNT" -ge "$REQUIRED_APPROVALS" ]; then


### PR DESCRIPTION
## What
This PR improves the workflow for handling pull requests with these updates:

- Automatically calculate required approvals based on the number of assigned reviewers.
- Prevent auto-merge when no reviewers are assigned.
- Add support for PR title patterns:
   - **`#M`**: Stops the workflow for manual reviewer assignment.
   - **`#n`**: Automatically assigns `n` reviewers. Defaults to 2 if no number is specified.

## How to Use
- Add **`#M`** to the PR title to disable automatic reviewer assignment.
- Add **`#n`** to the PR title to set the number of reviewers automatically. (n is an integer between 0 and 9.)
- **`#M` and `#n` cannot be used together**. If `#M` is used, `#n` will not work.


## Other Updates
- Improved error handling for cases with no reviewers.
- Disabled auto-merge for PRs targeting the master branch.

## translation
- This PR translates all messages in the workflow to Korean for better understanding and accessibility for the team.
______________________________________________________________________________________________________
## 내용
이 PR은 PR 처리를 개선하기 위해 워크플로우를 다음과 같이 업데이트했습니다:

- 할당된 리뷰어 수에 따라 필요한 승인 수를 자동으로 계산합니다.
- 리뷰어가 없을 때 자동 병합을 방지합니다.
- PR 제목 패턴을 지원합니다:
   - **`#M`**: 워크플로우를 중단하고 수동으로 리뷰어를 지정할 수 있습니다.
   - **`#n`**: `n`명의 리뷰어를 자동으로 지정합니다. 숫자가 없으면 기본값은 2명입니다. 

## 사용 방법
- PR 제목에 **`#M`**을 추가하면 자동 리뷰어 할당이 꺼집니다.
- PR 제목에 **`#n`**을 추가하면 리뷰어 숫자를 설정할 수 있습니다. (n은 0~9의 정수입니다.)
- **`#M`과 `#n`은 함께 사용할 수 없습니다**. `#M`을 사용하면 `#n`은 동작하지 않습니다.

## 기타 변경 사항
- 리뷰어가 없는 경우를 위한 에러 처리를 개선했습니다.
- master 브랜치를 대상으로 한 PR은 자동 병합되지 않습니다.

## 번역
- 이 PR은 워크플로우 내 모든 메시지를 한글로 번역하여 팀이 더 잘 이해하고 접근할 수 있도록 했습니다.