### PR TITLE
FIX: Main Path Configuration Update #M

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="22" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,8 +3,8 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/PlayerEnemyShipVariety.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/PlayerEnemyShipVariety.app.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/PlayerEnemyShipVariety.app.test.iml" filepath="$PROJECT_DIR$/.idea/modules/app/PlayerEnemyShipVariety.app.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" />
     </modules>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,12 @@ repositories {
 dependencies {
     // Use JUnit Jupiter for testing.
     testImplementation(libs.junit.jupiter)
-
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // This dependency is used by the application.
     implementation(libs.guava)
 }
+
 
 // Apply a specific Java toolchain to ease working on different environments.
 java {
@@ -34,13 +34,22 @@ java {
 
 application {
     // Define the main class for the application.
-    mainClass = "org.example.App"
+    mainClass = "engine.Core"
 }
 
 sourceSets {
+    main {
+        java {
+            setSrcDirs(listOf("src")) // 모든 실행 소스를 포함
+            exclude("**/Test/**")    // 테스트 디렉토리는 제외
+        }
+        resources {
+            setSrcDirs(listOf("res")) // 리소스 디렉토리 설정
+        }
+    }
     test {
         java {
-            setSrcDirs(listOf("src/Test"))
+            setSrcDirs(listOf("src/Test")) // 테스트 코드 경로 설정
         }
     }
 }

--- a/src/Test/engine/CoreTest.java
+++ b/src/Test/engine/CoreTest.java
@@ -1,0 +1,12 @@
+package engine;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CoreTest {
+
+    @Test
+    void main() {
+    }
+}


### PR DESCRIPTION
## Changes
- Updated the `build.gradle.kts` file to set the main class path to `engine.Core`.
- Clarified the source directory and test directory paths in the Gradle configuration.
- Resolved issues related to path settings during the build and test process.

## Key Updates
- Set the `mainClass` in the Gradle `application` plugin to `engine.Core`.
- Clearly defined paths for `sourceSets.main` and `sourceSets.test`.
- Fixed errors occurring during the Gradle build process.
_____________________________________________________________________________________
## 변경 사항
- `build.gradle.kts` 파일에서 메인 클래스 경로를 `engine.Core`로 수정.
- Gradle 설정에서 메인 소스 디렉토리 및 테스트 디렉토리의 경로를 명확히 지정.
- 빌드 및 테스트 과정에서 발생한 경로 설정 문제 해결.

## 주요 내용
- Gradle `application` 플러그인의 `mainClass`를 `engine.Core`로 설정.
- `sourceSets.main`과 `sourceSets.test`의 경로 설정을 명확히 업데이트.
- Gradle 빌드 시 발생하던 오류 해결.

![image](https://github.com/user-attachments/assets/7de29578-e686-4c7c-bb2c-7b8a35e8eb11)

![image](https://github.com/user-attachments/assets/1b567734-0c08-4bb0-be2c-76d4fdb36ee5)

