### PR TITLE
FEAT: Discord and Slack Alerts for Assigned Reviewers

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -29,13 +29,13 @@ jobs:
           # JSON 형식으로 리뷰어 데이터 정의
           REVIEWER_DATA='{
             "reviewers": [
-              {"github": "Dream-no24", "discord": "543412284823830542", "slack": "@U0815U6D5FA"},
-              {"github": "depave", "discord": "390393061462638592", "slack": "@U081Q5QNJQY"},
-              {"github": "this-yujunkim", "discord": "345678901234567890", "slack": "@U080VNUFAB0"},
-              {"github": "gmvolt", "discord": "456789012345678901", "slack": "@U080YD1SB9B"},
-              {"github": "Jangjimin9766", "discord": "622289999471181824", "slack": "@U081BSNUM6Y"},
-              {"github": "HSHyun", "discord": "1234432353859010600", "slack": "@U080LVALFHV"},
-              {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@U081N2GPY8H"}
+              {"github": "Dream-no24", "discord": "543412284823830542", "slack": "@경주"},
+              {"github": "depave", "discord": "390393061462638592", "slack": "@곽재민"},
+              {"github": "this-yujunkim", "discord": "345678901234567890", "slack": "@김유준"},
+              {"github": "gmvolt", "discord": "456789012345678901", "slack": "@김정우"},
+              {"github": "Jangjimin9766", "discord": "622289999471181824", "slack": "@장지민"},
+              {"github": "HSHyun", "discord": "1234432353859010600", "slack": "@현승현"},
+              {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@나건엽"}
             ]
           }'
 

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -13,11 +13,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq gh
+
       - name: Select Random Reviewers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         run: |
           # PR 정보 가져오기
           PR_TITLE="${{ github.event.pull_request.title }}"
@@ -39,7 +40,9 @@ jobs:
 
           # PR 작성자를 제외한 리뷰어 필터링
           FILTERED_REVIEWERS=$(echo "$REVIEWER_DATA" | jq -c --arg PR_AUTHOR "$PR_AUTHOR" \
-          '.reviewers | map(select(.github != $PR_AUTHOR))')
+            '.reviewers | map(select(.github != $PR_AUTHOR))')
+
+          echo "필터링된 리뷰어: $FILTERED_REVIEWERS"
 
           # PR 제목에서 '#M' 패턴 찾기
           if [[ "$PR_TITLE" =~ \#M$ ]]; then
@@ -57,14 +60,12 @@ jobs:
           fi
 
           # 무작위 리뷰어 선택
-          SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -c --argjson NUM_REVIEWERS $NUM_REVIEWERS \
-          'shuffle | .[:$NUM_REVIEWERS]')
+          SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -r '.[].github' | shuf -n "$NUM_REVIEWERS")
 
           echo "선택된 리뷰어: $SELECTED_REVIEWERS"
 
           # GitHub 리뷰어 JSON 생성
-          GITHUB_REVIEWERS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].github' | jq -R . | jq -s .)
-
+          GITHUB_REVIEWERS=$(echo "$SELECTED_REVIEWERS" | jq -R . | jq -s .)
           echo "GitHub 리뷰어: $GITHUB_REVIEWERS"
 
           # PR에 리뷰어 지정
@@ -76,17 +77,20 @@ jobs:
             -d "{\"reviewers\": $GITHUB_REVIEWERS}"
 
           # 디스코드 및 슬랙 멘션 생성
-          DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].discord | "<@" + . + ">"' | tr '\n' ' ')
-          SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].slack' | tr '\n' ' ')
+          DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r --argjson DATA "$REVIEWER_DATA" \
+            'split("\n") | map(select(length > 0) | $DATA.reviewers[] | select(.github == .) | .discord) | map("<@" + . + ">") | join(" ")')
+
+          SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r --argjson DATA "$REVIEWER_DATA" \
+            'split("\n") | map(select(length > 0) | $DATA.reviewers[] | select(.github == .) | .slack) | join(" ")')
 
           # 디스코드 알림 전송
           DISCORD_MESSAGE="리뷰어로 지정되었습니다!\nPR 제목: $PR_TITLE\nPR 링크: $PR_LINK\n리뷰어: ${DISCORD_MENTIONS}"
           curl -H "Content-Type: application/json" \
                -d "{\"content\": \"$DISCORD_MESSAGE\"}" \
-               $DISCORD_WEBHOOK
+               $DISCORD_WEBHOOK_URL || echo "Discord 알림 전송 실패"
 
           # 슬랙 알림 전송
           SLACK_MESSAGE="리뷰어로 지정되었습니다!\nPR 제목: $PR_TITLE\nPR 링크: $PR_LINK\n리뷰어: ${SLACK_MENTIONS}"
           curl -H "Content-Type: application/json" \
                -d "{\"text\": \"$SLACK_MESSAGE\"}" \
-               $SLACK_WEBHOOK
+               $SLACK_WEBHOOK_URL || echo "Slack 알림 전송 실패"

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -24,7 +24,8 @@ jobs:
           PR_TITLE="${{ github.event.pull_request.title }}"
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           PR_LINK="${{ github.event.pull_request.html_url }}"
-
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          
           # JSON 형식으로 리뷰어 데이터 정의
           REVIEWER_DATA='{
             "reviewers": [
@@ -37,11 +38,9 @@ jobs:
               {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@U081N2GPY8H"}
             ]
           }'
-
           # PR 작성자를 제외한 리뷰어 필터링
           FILTERED_REVIEWERS=$(echo "$REVIEWER_DATA" | jq -c --arg PR_AUTHOR "$PR_AUTHOR" \
             '.reviewers | map(select(.github != $PR_AUTHOR))')
-
           echo "필터링된 리뷰어: $FILTERED_REVIEWERS"
 
           # PR 제목에서 '#M' 패턴 찾기
@@ -61,7 +60,6 @@ jobs:
 
           # 무작위 리뷰어 선택
           SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -r '.[].github' | shuf -n "$NUM_REVIEWERS")
-
           echo "선택된 리뷰어: $SELECTED_REVIEWERS"
 
           # GitHub 리뷰어 JSON 생성
@@ -69,19 +67,20 @@ jobs:
           echo "GitHub 리뷰어: $GITHUB_REVIEWERS"
 
           # PR에 리뷰어 지정
-          PR_NUMBER="${{ github.event.pull_request.number }}"
           curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
-            -d "{\"reviewers\": $GITHUB_REVIEWERS}"
+               -X POST \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
+               -d "{\"reviewers\": $GITHUB_REVIEWERS}"
 
           # 디스코드 및 슬랙 멘션 생성
-          DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r --argjson DATA "$REVIEWER_DATA" \
-            'split("\n") | map(select(length > 0) | $DATA.reviewers[] | select(.github == .) | .discord) | map("<@" + . + ">") | join(" ")')
-
-          SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r --argjson DATA "$REVIEWER_DATA" \
-            'split("\n") | map(select(length > 0) | $DATA.reviewers[] | select(.github == .) | .slack) | join(" ")')
+          DISCORD_MENTIONS=$(echo "$FILTERED_REVIEWERS" | jq -r --argjson SELECTED "$SELECTED_REVIEWERS" \
+            '.[] | select(.github as $github | $SELECTED | index($github)) | "<@" + .discord + ">"' | tr '\n' ' ')
+          SLACK_MENTIONS=$(echo "$FILTERED_REVIEWERS" | jq -r --argjson SELECTED "$SELECTED_REVIEWERS" \
+            '.[] | select(.github as $github | $SELECTED | index($github)) | .slack' | tr '\n' ' ')
+          
+          echo "Discord 멘션: $DISCORD_MENTIONS"
+          echo "Slack 멘션: $SLACK_MENTIONS"
 
           # 디스코드 알림 전송
           DISCORD_MESSAGE="리뷰어로 지정되었습니다!\nPR 제목: $PR_TITLE\nPR 링크: $PR_LINK\n리뷰어: ${DISCORD_MENTIONS}"

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -25,7 +25,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           PR_LINK="${{ github.event.pull_request.html_url }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          
+
           # JSON 형식으로 리뷰어 데이터 정의
           REVIEWER_DATA='{
             "reviewers": [
@@ -38,6 +38,7 @@ jobs:
               {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@U081N2GPY8H"}
             ]
           }'
+
           # PR 작성자를 제외한 리뷰어 필터링
           FILTERED_REVIEWERS=$(echo "$REVIEWER_DATA" | jq -c --arg PR_AUTHOR "$PR_AUTHOR" \
             '.reviewers | map(select(.github != $PR_AUTHOR))')
@@ -59,11 +60,12 @@ jobs:
           fi
 
           # 무작위 리뷰어 선택
-          SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -r '.[].github' | shuf -n "$NUM_REVIEWERS")
+          SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -c --argjson NUM_REVIEWERS "$NUM_REVIEWERS" \
+            'sort_by(.github) | .[:$NUM_REVIEWERS]')
           echo "선택된 리뷰어: $SELECTED_REVIEWERS"
 
           # GitHub 리뷰어 JSON 생성
-          GITHUB_REVIEWERS=$(echo "$SELECTED_REVIEWERS" | jq -R . | jq -s .)
+          GITHUB_REVIEWERS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].github' | jq -R . | jq -s .)
           echo "GitHub 리뷰어: $GITHUB_REVIEWERS"
 
           # PR에 리뷰어 지정
@@ -74,11 +76,11 @@ jobs:
                -d "{\"reviewers\": $GITHUB_REVIEWERS}"
 
           # 디스코드 및 슬랙 멘션 생성
-          DISCORD_MENTIONS=$(echo "$FILTERED_REVIEWERS" | jq -r --argjson SELECTED "$SELECTED_REVIEWERS" \
-            '.[] | select(.github as $github | $SELECTED | index($github)) | "<@" + .discord + ">"' | tr '\n' ' ')
-          SLACK_MENTIONS=$(echo "$FILTERED_REVIEWERS" | jq -r --argjson SELECTED "$SELECTED_REVIEWERS" \
-            '.[] | select(.github as $github | $SELECTED | index($github)) | .slack' | tr '\n' ' ')
-          
+          DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r \
+            '.[] | "<@" + .discord + ">"' | tr '\n' ' ')
+          SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r \
+            '.[] | .slack' | tr '\n' ' ')
+
           echo "Discord 멘션: $DISCORD_MENTIONS"
           echo "Slack 멘션: $SLACK_MENTIONS"
 

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -16,28 +16,37 @@ jobs:
       - name: Select Random Reviewers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: |
-          # PR 제목 가져오기
-          PR_TITLE=$(jq --raw-output .pull_request.title "$GITHUB_EVENT_PATH")
-          echo "PR 제목: $PR_TITLE"
-          
-          # 7명의 조원 GitHub 아이디를 배열에 저장
-          REVIEWERS=("Dream-no24" "depave" "this-yujunkim" "gmvolt" "Jangjimin9766" "HSHyun" "NaJhinY")
-          
-          # PR 작성자 아이디 가져오기
-          PR_AUTHOR=$(jq --raw-output .pull_request.user.login "$GITHUB_EVENT_PATH")
-          
-          # PR 작성자를 제외한 배열 생성
-          FILTERED_REVIEWERS=()
-          for reviewer in "${REVIEWERS[@]}"; do
-            if [[ "$reviewer" != "$PR_AUTHOR" ]]; then
-              FILTERED_REVIEWERS+=("$reviewer")
-            fi
-          done
+          # PR 정보 가져오기
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          PR_LINK="${{ github.event.pull_request.html_url }}"
+
+          # JSON 형식으로 리뷰어 데이터 정의
+          REVIEWER_DATA='{
+            "reviewers": [
+              {"github": "Dream-no24", "discord": "543412284823830542", "slack": "@U0815U6D5FA"},
+              {"github": "depave", "discord": "390393061462638592", "slack": "@U081Q5QNJQY"},
+              {"github": "this-yujunkim", "discord": "345678901234567890", "slack": "@U080VNUFAB0"},
+              {"github": "gmvolt", "discord": "456789012345678901", "slack": "@U080YD1SB9B"},
+              {"github": "Jangjimin9766", "discord": "622289999471181824", "slack": "@U081BSNUM6Y"},
+              {"github": "HSHyun", "discord": "1234432353859010600", "slack": "@U080LVALFHV"},
+              {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@U081N2GPY8H"}
+            ]
+          }'
+
+          # PR 작성자를 제외한 리뷰어 필터링
+          FILTERED_REVIEWERS=$(echo "$REVIEWER_DATA" | jq -c --arg PR_AUTHOR "$PR_AUTHOR" \
+          '.reviewers | map(select(.github != $PR_AUTHOR))')
+
           # PR 제목에서 '#M' 패턴 찾기
           if [[ "$PR_TITLE" =~ \#M$ ]]; then
-            exit 0  # 워크플로우 종료 (자동 리뷰어 할당을 하지 않음)
+            echo "리뷰어 자동 할당이 비활성화되었습니다."
+            exit 0
           fi
+
           # PR 제목에서 '#n' 패턴 찾기
           if [[ "$PR_TITLE" =~ \#([0-9]+)$ ]]; then
             NUM_REVIEWERS=${BASH_REMATCH[1]}
@@ -46,22 +55,38 @@ jobs:
             NUM_REVIEWERS=2
             echo "리뷰어 수가 명시되지 않았으므로 기본값 $NUM_REVIEWERS명을 선택합니다."
           fi
-          # 배열에서 n명을 무작위로 선택
-          SELECTED_REVIEWERS=($(shuf -e "${FILTERED_REVIEWERS[@]}" -n "$NUM_REVIEWERS"))
-          
-          echo "선택된 리뷰어: ${SELECTED_REVIEWERS[@]}"
-          
-          # 선택된 리뷰어를 GitHub API 형식에 맞춰 JSON 배열로 변환
-          JSON_REVIEWERS=$(printf '%s\n' "${SELECTED_REVIEWERS[@]}" | jq -R . | jq -s .)
-          
-          echo "리뷰어 JSON: $JSON_REVIEWERS"
-          
-          # PR 번호 가져오기
-          PR_NUMBER=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
-          
-          # GitHub API를 통해 PR에 리뷰어 지정
+
+          # 무작위 리뷰어 선택
+          SELECTED_REVIEWERS=$(echo "$FILTERED_REVIEWERS" | jq -c --argjson NUM_REVIEWERS $NUM_REVIEWERS \
+          'shuffle | .[:$NUM_REVIEWERS]')
+
+          echo "선택된 리뷰어: $SELECTED_REVIEWERS"
+
+          # GitHub 리뷰어 JSON 생성
+          GITHUB_REVIEWERS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].github' | jq -R . | jq -s .)
+
+          echo "GitHub 리뷰어: $GITHUB_REVIEWERS"
+
+          # PR에 리뷰어 지정
+          PR_NUMBER="${{ github.event.pull_request.number }}"
           curl -s -H "Authorization: token $GITHUB_TOKEN" \
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" \
-            -d "{\"reviewers\": $JSON_REVIEWERS}"
+            -d "{\"reviewers\": $GITHUB_REVIEWERS}"
+
+          # 디스코드 및 슬랙 멘션 생성
+          DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].discord | "<@" + . + ">"' | tr '\n' ' ')
+          SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r '.[].slack' | tr '\n' ' ')
+
+          # 디스코드 알림 전송
+          DISCORD_MESSAGE="리뷰어로 지정되었습니다!\nPR 제목: $PR_TITLE\nPR 링크: $PR_LINK\n리뷰어: ${DISCORD_MENTIONS}"
+          curl -H "Content-Type: application/json" \
+               -d "{\"content\": \"$DISCORD_MESSAGE\"}" \
+               $DISCORD_WEBHOOK
+
+          # 슬랙 알림 전송
+          SLACK_MESSAGE="리뷰어로 지정되었습니다!\nPR 제목: $PR_TITLE\nPR 링크: $PR_LINK\n리뷰어: ${SLACK_MENTIONS}"
+          curl -H "Content-Type: application/json" \
+               -d "{\"text\": \"$SLACK_MESSAGE\"}" \
+               $SLACK_WEBHOOK

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -29,13 +29,13 @@ jobs:
           # JSON 형식으로 리뷰어 데이터 정의
           REVIEWER_DATA='{
             "reviewers": [
-              {"github": "Dream-no24", "discord": "543412284823830542", "slack": "@경주"},
-              {"github": "depave", "discord": "390393061462638592", "slack": "@곽재민"},
-              {"github": "this-yujunkim", "discord": "345678901234567890", "slack": "@김유준"},
-              {"github": "gmvolt", "discord": "456789012345678901", "slack": "@김정우"},
-              {"github": "Jangjimin9766", "discord": "622289999471181824", "slack": "@장지민"},
-              {"github": "HSHyun", "discord": "1234432353859010600", "slack": "@현승현"},
-              {"github": "NaJhinY", "discord": "309497537696628746", "slack": "@나건엽"}
+              {"github": "Dream-no24", "discord": "543412284823830542", "slack": "U0815U6D5FA"},
+              {"github": "depave", "discord": "390393061462638592", "slack": "U081Q5QNJQY"},
+              {"github": "this-yujunkim", "discord": "345678901234567890", "slack": "U080VNUFAB0"},
+              {"github": "gmvolt", "discord": "456789012345678901", "slack": "U080YD1SB9B"},
+              {"github": "Jangjimin9766", "discord": "622289999471181824", "slack": "U081BSNUM6Y"},
+              {"github": "HSHyun", "discord": "1234432353859010600", "slack": "U080LVALFHV"},
+              {"github": "NaJhinY", "discord": "309497537696628746", "slack": "U081N2GPY8H"}
             ]
           }'
 
@@ -79,7 +79,7 @@ jobs:
           DISCORD_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r \
             '.[] | "<@" + .discord + ">"' | tr '\n' ' ')
           SLACK_MENTIONS=$(echo "$SELECTED_REVIEWERS" | jq -r \
-            '.[] | .slack' | tr '\n' ' ')
+            '.[] | "<@" + .slack + ">"' | tr '\n' ' ')
 
           echo "Discord 멘션: $DISCORD_MENTIONS"
           echo "Slack 멘션: $SLACK_MENTIONS"


### PR DESCRIPTION
## 변경 사항
- 기존의 무작위 리뷰어 지정 기능에 알림 기능 추가.
- 리뷰어가 지정될 때 디스코드와 슬랙을 통해 알림 발송.

## 주요 기능
- 디스코드:
  - 선택된 리뷰어의 디스코드 ID를 이용해 멘션 알림 발송.
- 슬랙:
  - 선택된 리뷰어의 슬랙 ID를 이용해 멘션 알림 발송.
- 알림 메시지에는 PR 제목, 작성자, 링크가 포함됩니다.

## 테스트
- 테스트 환경에서 리뷰어 지정 시 디스코드와 슬랙 알림이 정상적으로 전송됨을 확인.

_________________________________________________________________________________________________

## Changes
- Added notification feature to the existing random reviewer assignment functionality.
- Sends alerts via Discord and Slack when reviewers are assigned.

## Key Features
- **Discord**:
  - Sends mentions to the selected reviewers using their Discord IDs.
- **Slack**:
  - Sends mentions to the selected reviewers using their Slack IDs.
- Notification messages include the PR title, author, and link.

## Testing
- Verified in the test environment that Discord and Slack alerts are sent successfully when reviewers are assigned.
