### PR TITLE
FEAT: Implemented Damaged Sprite for CrabBoss

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" filepath="$PROJECT_DIR$/.idea/modules/PlayerEnemyShipVariety.test.iml" />
-    </modules>
-  </component>
-</project>

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -125,18 +125,18 @@ public class DrawManager {
 		BossALeft2,
 		BossACore2,
 		BossARight2,
-		BossABorderLeft1,
-		BossABorderCore1,
-		BossABorderRight1,
-		BossABorderLeft2,
-		BossABorderCore2,
-		BossABorderRight2,
+		BossALeftDamaged,
+		BossACoreDamaged,
+		BossARightDamaged,
+		BossALeftDamaged2,
+		BossACoreDamaged2,
+		BossARightDamaged2,
 
 		BossBCore1,
 		BossBCore2,
+		BossBCoreShell,
 		BossBCoreDamaged,
-		BossBCoreBorder1,
-		BossBCoreBorder2
+		BossBCoreDamaged2
 	};
 
 	/**
@@ -190,18 +190,18 @@ public class DrawManager {
 			spriteMap.put(SpriteType.BossALeft2, new boolean[24][48]);
 			spriteMap.put(SpriteType.BossACore2, new boolean[24][48]);
 			spriteMap.put(SpriteType.BossARight2, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderLeft1, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderCore1, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderRight1, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderLeft2, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderCore2, new boolean[24][48]);
-			spriteMap.put(SpriteType.BossABorderRight2, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossALeftDamaged, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossACoreDamaged, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossARightDamaged, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossALeftDamaged2, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossACoreDamaged2, new boolean[24][48]);
+			spriteMap.put(SpriteType.BossARightDamaged2, new boolean[24][48]);
 			// Turtle
 			spriteMap.put(SpriteType.BossBCore1, new boolean[150][180]);
 			spriteMap.put(SpriteType.BossBCore2, new boolean[150][180]);
+			spriteMap.put(SpriteType.BossBCoreShell, new boolean[150][180]);
 			spriteMap.put(SpriteType.BossBCoreDamaged, new boolean[150][180]);
-			spriteMap.put(SpriteType.BossBCoreBorder1, new boolean[150][180]);
-			spriteMap.put(SpriteType.BossBCoreBorder2, new boolean[150][180]);
+			spriteMap.put(SpriteType.BossBCoreDamaged2, new boolean[150][180]);
 
 			fileManager.loadSprite(spriteMap);
 			logger.info("Finished loading the sprites.");

--- a/src/entity/BossFormation.java
+++ b/src/entity/BossFormation.java
@@ -173,9 +173,9 @@ public class BossFormation implements Iterable<BossParts> {
             switch (spriteType) {
                 case BossBCore1:
                 case BossBCore2:
+                case BossBCoreShell:
                 case BossBCoreDamaged:
-                case BossBCoreBorder1:
-                case BossBCoreBorder2:
+                case BossBCoreDamaged2:
                     this.positionX = 20;
                     this.positionY = -150;
                     break;
@@ -193,20 +193,20 @@ public class BossFormation implements Iterable<BossParts> {
                 case BossALeft2:
                 case BossARight1:
                 case BossARight2:
-                case BossABorderCore1:
-                case BossABorderCore2:
-                case BossABorderLeft1:
-                case BossABorderLeft2:
-                case BossABorderRight1:
-                case BossABorderRight2:
+                case BossACoreDamaged:
+                case BossACoreDamaged2:
+                case BossALeftDamaged:
+                case BossALeftDamaged2:
+                case BossARightDamaged:
+                case BossARightDamaged2:
                     BossWidth = 24;
                     BossHeight = 48;
                     break;
                 case BossBCore1:
                 case BossBCore2:
+                case BossBCoreShell:
                 case BossBCoreDamaged:
-                case BossBCoreBorder1:
-                case BossBCoreBorder2:
+                case BossBCoreDamaged2:
                     BossWidth = 150;
                     BossHeight = 180;
                     break;

--- a/src/entity/BossParts.java
+++ b/src/entity/BossParts.java
@@ -119,7 +119,7 @@ public class BossParts extends Entity {
 				case BossBCore1:
 					// Check skill cooldown and change sprite type to B3 which is B3.
 					if (this.bossBActiveSkillCooldown.checkFinished()) {
-						this.spriteType = SpriteType.BossBCoreDamaged;
+						this.spriteType = SpriteType.BossBCoreShell;
 						bossBActiveSkillDuration.reset();
 					}
 					else
@@ -128,13 +128,13 @@ public class BossParts extends Entity {
 				case BossBCore2:
 					this.spriteType = SpriteType.BossBCore1;
 					break;
-				case BossBCoreDamaged:
+				case BossBCoreShell:
 					if (this.bossBActiveSkillDuration.checkFinished()) {
 						this.spriteType = SpriteType.BossBCore1;
 						bossBActiveSkillCooldown.reset();
 					}
 					else
-						this.spriteType = SpriteType.BossBCoreDamaged;
+						this.spriteType = SpriteType.BossBCoreShell;
 				default:
 					break;
 			}

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -709,7 +709,7 @@ public class GameScreen extends Screen {
 					for (BossParts bossParts : this.bossFormation) {
 						if (!bossParts.isDestroyed()
 								&& checkCollision(bullet, bossParts)) {
-							if (bossParts.getSpriteType().equals(DrawManager.SpriteType.BossBCoreDamaged)) {
+							if (bossParts.getSpriteType().equals(DrawManager.SpriteType.BossBCoreShell)) {
 								isShell = true;
 								hitPositionX = bullet.getPositionX();
 								hitPositionY = bullet.getPositionY();


### PR DESCRIPTION
## What
Implemented Damaged Sprite for CrabBoss.

## Additional Information
Changed Sprite name "~Border" to "~Damaged".
Changed Turtle Boss previous Damaged Sprite name to BossBCoreShell.

***

## What
추가된 보스 피격 스프라이트를 적용했습니다.

## Additional Information
"~Border"으로 명명되었던 Damaged 스프라이트 이름을 "~Damaged"로 변경하였습니다.
기존의 BossBDamaged 스프라이트를 BossBCoreShell로 변경하였습니다.